### PR TITLE
fix: copy sfc descriptor to prevent caching issues

### DIFF
--- a/src/serverPlugin.ts
+++ b/src/serverPlugin.ts
@@ -73,13 +73,17 @@ export const vuePlugin: ServerPlugin = ({
     const publicPath = ctx.path
     let filePath = resolver.requestToFile(publicPath)
     const source = readFile(filePath)
-    const descriptor = parse({
-      source,
-      compiler: vueTemplateCompiler,
-      filename: filePath,
-      sourceRoot: root,
-      needMap: true,
-    }) as SFCDescriptor
+    const descriptor = JSON.parse(
+      JSON.stringify(
+        parse({
+          source,
+          compiler: vueTemplateCompiler,
+          filename: filePath,
+          sourceRoot: root,
+          needMap: true,
+        })
+      )
+    ) as SFCDescriptor
     if (!descriptor) {
       return
     }
@@ -183,7 +187,8 @@ async function parseSFC(
   }
 
   let code =
-    `${scriptImport}
+    `
+${scriptImport}
 ${templateImport}
 const __cssModules = {}
 ${stylesCode}

--- a/src/serverPlugin.ts
+++ b/src/serverPlugin.ts
@@ -187,8 +187,7 @@ async function parseSFC(
   }
 
   let code =
-    `
-${scriptImport}
+    `${scriptImport}
 ${templateImport}
 const __cssModules = {}
 ${stylesCode}


### PR DESCRIPTION
The parse function in @vue/component-compiler-utils caches the result based on a hash of the source. Since the sourcemap object on the descriptor gets mutated, it will try merging the sourcemaps multiple times on the same descriptor reference if you make a second request before the first one finishes.