### PR TITLE
Fix asset transform paths, fix SFCs with no template tag, fix babel preset resolution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,11 @@ export function createVuePlugin(rawOptions: VueViteOptions = {}): Plugin {
       return handleHotUpdate(ctx, options)
     },
 
+    configResolved(config) {
+      options.isProduction = config.isProduction
+      options.root = config.root
+    },
+
     configureServer(server) {
       options.devServer = server
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,7 @@ export function createVuePlugin(rawOptions: VueViteOptions = {}): Plugin {
     async transform(code, id) {
       const { filename, query } = parseVueRequest(id)
 
-      if (/\.(tsx?|jsx)$/.test(id)) {
+      if (/\.(tsx|jsx)$/.test(id)) {
         return transformVueJsx(code, id)
       }
 

--- a/src/jsxTransform.ts
+++ b/src/jsxTransform.ts
@@ -3,7 +3,7 @@ import { transform } from '@babel/core'
 // todo hmr
 export function transformVueJsx(code: string, filename: string) {
   const result = transform(code, {
-    presets: ['@vue/babel-preset-jsx'],
+    presets: [require('@vue/babel-preset-jsx')],
     filename,
     sourceMaps: true,
   })!

--- a/src/main.ts
+++ b/src/main.ts
@@ -146,7 +146,7 @@ async function genScriptCode(
 function genTemplateRequest(filename: string, descriptor: SFCDescriptor) {
   const template = descriptor.template
   if (!template) {
-    return { code: `const render, staticRenderFns` }
+    return { code: `let render, staticRenderFns` }
   }
   if (template.src) {
     linkSrcToDescriptor(template.src, filename, descriptor)

--- a/src/template.ts
+++ b/src/template.ts
@@ -2,6 +2,7 @@ import { SFCBlock, compileTemplate } from '@vue/component-compiler-utils'
 import * as vueTemplateCompiler from 'vue-template-compiler'
 import path from 'path'
 import { TransformPluginContext } from 'rollup'
+import slash from 'slash'
 import { ResolvedOptions } from './index'
 import { createRollupError } from './utils/error'
 
@@ -19,7 +20,7 @@ export function compileSFCTemplate(
     transformAssetUrls: true,
     transformAssetUrlsOptions: devServer
       ? {
-          base: path.posix.dirname(path.relative(root, filename)),
+          base: '/' + slash(path.relative(root, path.dirname(filename))),
         }
       : {},
     isProduction,


### PR DESCRIPTION
- `path.posix` does not consider backslashes to be a delimiter, so asset urls were not working on Windows. The `root` was also not taking the user configuration into consideration.
- When there is no template tag, the template code defaults to `const render, staticRenderFns`, which is not a valid statement, since you can't have an uninitialized const.
- I also had issues in a yarn monorepo, where some other dependency conflicts made it so that `@vue/babel-preset-jsx` could not be hoisted to the top level. Instead, it was located under vite-plugin-vue2, i.e. `node_modules/vite-plugin-vue2/node_modules/@vue/babel-preset-jsx`, which made it so Vite could not resolve `@vue/babel-preset-jsx`. Changing this to a `require` call seems to fix this.