### PR TITLE
determine preprocessLang dynamically

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -24,6 +24,7 @@ export function compileSFCTemplate(
     isFunctional: !!block.attrs.functional,
     optimizeSSR: false,
     prettify: false,
+    preprocessLang: block.lang,
     ...vueTemplateOptions,
   })
 


### PR DESCRIPTION
I have a patch that tries to add tests but getting vite consolidate require resolution errors when installing `pug` in the `playground` directory, for example. Also getting typescript compilation errors -- are you getting those too or am I set up incorrectly?

I also was thinking about `vueTemplateOptions` allowing a function but it is called in a place without the `SFCBlock` so it was not very clean (because right now I might want to set options for `pug`, but not `html`, for example).

Let me know if I'm going about this completely the wrong way too, please!