### PR TITLE
fix: babel transform need filename options

### DIFF
--- a/src/jsxTransform.ts
+++ b/src/jsxTransform.ts
@@ -15,6 +15,7 @@ export function transformVueJsx(
   }
 
   const result = transform(code, {
+    filename: 'jsx-transform.ts',
     presets: [[require.resolve('@vue/babel-preset-jsx'), jsxOptions]],
     sourceFileName: id,
     sourceMaps: true,


### PR DESCRIPTION
from 1.4.2, when Vue SFC has <script lang="jsx">, these errors shown:
```shell
2:13:26 ├F10: PM┤ [vite] Internal server error: [BABEL] unknown: Preset /* your preset */ requires a filename to be set when babel is called directly,
```
babel.transform(code, { filename: 'file.ts', presets: [/* your preset */] });
```
See https://babeljs.io/docs/en/options#filename for more information.
  Plugin: vite-plugin-vue2
  File: /Users/indexxuan/github/vue-enterprise-boilerplate/src/components/nav-bar-routes.vue?vue&type=script&lang.jsx
      at validateIfOptionNeedsFilename (/Users/indexxuan/github/vue-enterprise-boilerplate/node_modules/@babel/core/lib/config/full.js:286:11)
      at /Users/indexxuan/github/vue-enterprise-boilerplate/node_modules/@babel/core/lib/config/full.js:298:52
      at Array.forEach (<anonymous>)
      at validatePreset (/Users/indexxuan/github/vue-enterprise-boilerplate/node_modules/@babel/core/lib/config/full.js:298:25)
      at loadPresetDescriptor (/Users/indexxuan/github/vue-enterprise-boilerplate/node_modules/@babel/core/lib/config/full.js:305:3)
      at loadPresetDescriptor.next (<anonymous>)
      at recursePresetDescriptors (/Users/indexxuan/github/vue-enterprise-boilerplate/node_modules/@babel/core/lib/config/full.js:112:30)
      at recursePresetDescriptors.next (<anonymous>)
      at /Users/indexxuan/github/vue-enterprise-boilerplate/node_modules/@babel/core/lib/config/full.js:186:21
      at Generator.next (<anonymous>)
      at loadFullConfig (/Users/indexxuan/github/vue-enterprise-boilerplate/node_modules/@babel/core/lib/config/full.js:142:5)
      at loadFullConfig.next (<anonymous>)
      at Function.transform (/Users/indexxuan/github/vue-enterprise-boilerplate/node_modules/@babel/core/lib/transform.js:25:45)
      at transform.next (<anonymous>)
      at evaluateSync (/Users/indexxuan/github/vue-enterprise-boilerplate/node_modules/gensync/index.js:251:28)
      at Function.sync (/Users/indexxuan/github/vue-enterprise-boilerplate/node_modules/gensync/index.js:89:14) (x5)
```