### PR TITLE
feat: default compilerOptions: whitespace: 'condense'

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -16,6 +16,9 @@ export function compileSFCTemplate(
     source,
     filename,
     compiler: vueTemplateCompiler as any,
+    compilerOptions: {
+      whitespace: 'condense'
+    },
     transformAssetUrls: true,
     transformAssetUrlsOptions: {
       forceRequire: true,

--- a/src/template.ts
+++ b/src/template.ts
@@ -16,9 +16,6 @@ export function compileSFCTemplate(
     source,
     filename,
     compiler: vueTemplateCompiler as any,
-    compilerOptions: {
-      whitespace: 'condense'
-    },
     transformAssetUrls: true,
     transformAssetUrlsOptions: {
       forceRequire: true,
@@ -29,6 +26,10 @@ export function compileSFCTemplate(
     prettify: false,
     preprocessLang: block.lang,
     ...vueTemplateOptions,
+    compilerOptions: {
+      whitespace: 'condense',
+      ...(vueTemplateOptions.compilerOptions || {})
+    }
   })
 
   if (tips) {

--- a/src/template/compileTemplate.ts
+++ b/src/template/compileTemplate.ts
@@ -122,13 +122,7 @@ function actuallyCompile(
   const compile =
     optimizeSSR && compiler.ssrCompile ? compiler.ssrCompile : compiler.compile
 
-  const defaultCompilerOptions: VueTemplateCompilerOptions = {
-    whitespace: 'condense'
-  }
-
-  let finalCompilerOptions =
-    Object.assign(defaultCompilerOptions, compilerOptions)
-
+  let finalCompilerOptions = compilerOptions
   if (transformAssetUrls) {
     const builtInModules = [
       transformAssetUrls === true
@@ -136,7 +130,7 @@ function actuallyCompile(
         : assetUrlsModule(transformAssetUrls, transformAssetUrlsOptions),
       srcsetModule(transformAssetUrlsOptions),
     ]
-    finalCompilerOptions = Object.assign(defaultCompilerOptions, compilerOptions, {
+    finalCompilerOptions = Object.assign({}, compilerOptions, {
       modules: [...builtInModules, ...(compilerOptions.modules || [])],
       filename: options.filename,
     })

--- a/src/template/compileTemplate.ts
+++ b/src/template/compileTemplate.ts
@@ -122,7 +122,13 @@ function actuallyCompile(
   const compile =
     optimizeSSR && compiler.ssrCompile ? compiler.ssrCompile : compiler.compile
 
-  let finalCompilerOptions = compilerOptions
+  const defaultCompilerOptions: VueTemplateCompilerOptions = {
+    whitespace: 'condense'
+  }
+
+  let finalCompilerOptions =
+    Object.assign(defaultCompilerOptions, compilerOptions)
+
   if (transformAssetUrls) {
     const builtInModules = [
       transformAssetUrls === true
@@ -130,7 +136,7 @@ function actuallyCompile(
         : assetUrlsModule(transformAssetUrls, transformAssetUrlsOptions),
       srcsetModule(transformAssetUrlsOptions),
     ]
-    finalCompilerOptions = Object.assign({}, compilerOptions, {
+    finalCompilerOptions = Object.assign(defaultCompilerOptions, compilerOptions, {
       modules: [...builtInModules, ...(compilerOptions.modules || [])],
       filename: options.filename,
     })


### PR DESCRIPTION
By default, template compilation does not remove space (set `whitespace:'condense'`). This leads to inconsistent behavior of the UI library. For example, the lack of removing spaces results in spaces in `inline-block` elements, This behavior is also inconsistent with vue-loader.

It can be solved like this:
```js
export default defineConfig({
  // ...
  plugins: [
    createVuePlugin({
      jsx: true,
      vueTemplateOptions: {
        compilerOptions: {
          whitespace: 'condense'
        }
      },
    })
    // ...
  ]
})
```

But I think in most cases, spaces should be removed. So I think `whitespace: 'condense'` should be the default configuration.