### PR TITLE
fix: babel transform ignore babel.config.js file

### DIFF
--- a/src/jsxTransform.ts
+++ b/src/jsxTransform.ts
@@ -21,6 +21,7 @@ export function transformVueJsx(
     sourceMaps: true,
     plugins,
     babelrc: false,
+    configFile: false
   })!
 
   return {


### PR DESCRIPTION
at the same question in #54 , should ignore babel.cofig.js too.