### PR TITLE
feat: unicode filename support (#81)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "debug": "^4.3.1",
     "fs-extra": "^9.0.1",
     "hash-sum": "^2.0.0",
+    "identifierfy": "^2.0.0",
     "magic-string": "^0.25.7",
     "prettier": "^2.0.5",
     "querystring": "^0.2.0",

--- a/src/template.ts
+++ b/src/template.ts
@@ -4,6 +4,7 @@ import { TransformPluginContext } from 'rollup'
 import { ResolvedOptions } from './index'
 import { createRollupError } from './utils/error'
 import { compileTemplate } from './template/compileTemplate'
+const identifierfy = require('identifierfy')
 
 export function compileSFCTemplate(
   source: string,
@@ -75,8 +76,7 @@ export function transformRequireToImport(code: string): string {
     /require\(("(?:[^"\\]|\\.)+"|'(?:[^'\\]|\\.)+')\)/g,
     (_, name): any => {
       if (!(name in imports)) {
-        imports[name] = `__$_require_${name
-          .replace(/[^a-z0-9]/g, '_')
+        imports[name] = `__$_require_${identifierfy(name)
           .replace(/_{2,}/g, '_')
           .replace(/^_|_$/g, '')}__`
         strImports += 'import ' + imports[name] + ' from ' + name + '\n'


### PR DESCRIPTION
#81 
use packge [identifierfy](github.com/novemberborn/identifierfy)  replace `replace(/[^a-z0-9]/g, '_')`  to support unicode identifiers.


 