### PR TITLE
fix(template): tips shouldn't use error to throw, should be use warn

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,12 +36,6 @@ export interface VueViteOptions {
    */
   jsx?: boolean
   /**
-   * The options for template-compiler warn handle,
-   * true = no warn, false = Allow warn
-   * @default false
-   */
-  strictWarn?: boolean
-  /**
    * The options for `@vue/babel-preset-jsx`
    */
   jsxOptions?: Record<string, any>

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,12 @@ export interface VueViteOptions {
    */
   jsx?: boolean
   /**
+   * The options for template-compiler warn handle,
+   * true = no warn, false = Allow warn
+   * @default false
+   */
+  strictWarn?: boolean
+  /**
    * The options for `@vue/babel-preset-jsx`
    */
   jsxOptions?: Record<string, any>

--- a/src/template.ts
+++ b/src/template.ts
@@ -10,7 +10,13 @@ export function compileSFCTemplate(
   source: string,
   block: SFCBlock,
   filename: string,
-  { root, isProduction, vueTemplateOptions = {}, devServer }: ResolvedOptions,
+  {
+    root,
+    isProduction,
+    vueTemplateOptions = {},
+    devServer,
+    strictWarn,
+  }: ResolvedOptions,
   pluginContext: TransformPluginContext
 ) {
   const { tips, errors, code } = compileTemplate({
@@ -34,8 +40,9 @@ export function compileSFCTemplate(
   })
 
   if (tips) {
+    const tipHandler = strictWarn ? pluginContext.error : pluginContext.warn
     tips.forEach((warn) =>
-      pluginContext.warn({
+      tipHandler({
         id: filename,
         message: typeof warn === 'string' ? warn : warn.msg,
       })

--- a/src/template.ts
+++ b/src/template.ts
@@ -10,13 +10,7 @@ export function compileSFCTemplate(
   source: string,
   block: SFCBlock,
   filename: string,
-  {
-    root,
-    isProduction,
-    vueTemplateOptions = {},
-    devServer,
-    strictWarn,
-  }: ResolvedOptions,
+  { root, isProduction, vueTemplateOptions = {}, devServer }: ResolvedOptions,
   pluginContext: TransformPluginContext
 ) {
   const { tips, errors, code } = compileTemplate({
@@ -40,9 +34,8 @@ export function compileSFCTemplate(
   })
 
   if (tips) {
-    const tipHandler = strictWarn ? pluginContext.error : pluginContext.warn
     tips.forEach((warn) =>
-      tipHandler({
+      pluginContext.warn({
         id: filename,
         message: typeof warn === 'string' ? warn : warn.msg,
       })

--- a/src/template.ts
+++ b/src/template.ts
@@ -35,7 +35,7 @@ export function compileSFCTemplate(
 
   if (tips) {
     tips.forEach((warn) =>
-      pluginContext.error({
+      pluginContext.warn({
         id: filename,
         message: typeof warn === 'string' ? warn : warn.msg,
       })


### PR DESCRIPTION
I think `vue-template-compiler` thrown tips shouldn't use error to throw, should be use warn handle.
tips level should not block development