### PR TITLE
fix: add pure annotations for tree shaking support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -50,7 +50,7 @@ const ${cssModuleVar} = {}
 ${stylesCode}
 /* normalize component */
 import normalizer from "${vueComponentNormalizer}"
-var component = normalizer(
+var component = /*#__PURE__*/normalizer(
   script,
   render,
   staticRenderFns,
@@ -106,7 +106,7 @@ function injectStyles (context) {
     map = JSON.parse(emptyMapGen.toString())
   }
 
-  result += `\nexport default component.exports`
+  result += `\nexport default /*#__PURE__*/(function () { return component.exports })()`
   return {
     code: result,
     map,


### PR DESCRIPTION
Fixes: https://github.com/underfin/vite-plugin-vue2/issues/104 

This is a similar fix to what is done here in [vue-component-compiler](https://github.com/vuejs/vue-component-compiler/commit/7b4dceb0b7212b0ca3202969bc6c2081c2d88b2b#diff-2d578e92f66f7733cbb1df008750c20408c85d45d969629467cfe336c03c9f55). Except I also had to add an IIFE with a pure annotation around the default export otherwise it still wouldn't get dropped when it was unused.