### PR TITLE
fix style of scoped

### DIFF
--- a/src/style.ts
+++ b/src/style.ts
@@ -16,7 +16,7 @@ export async function transformStyle(
     filename,
     id: `data-v-${descriptor.id}`,
     map: pluginContext.getCombinedSourcemap(),
-    scoped: !!block.scoped,
+    scoped: !!block?.scoped,
     trim: true,
   })
 


### PR DESCRIPTION
The result of `const block = descriptor.styles[index];` could be undefined.
![image](https://user-images.githubusercontent.com/38392315/127953247-ea5c6246-8e42-4616-a343-fa7a72592c3c.png)
