### PR TITLE
fix: add the support of the asset url without protocol header

### DIFF
--- a/playground/test-assets/TestAssets.vue
+++ b/playground/test-assets/TestAssets.vue
@@ -16,6 +16,10 @@
       Absolute asset reference in template:
       <img src="/favicon.ico" style="width: 30px;" />
     </p>
+    <p>
+      Absolute asset reference without protocol header in the template: 
+      <img src="//cli.vuejs.org/favicon.png" style="width: 30px;" />
+    </p>
   </div>
 </template>
 

--- a/src/template/utils.ts
+++ b/src/template/utils.ts
@@ -16,7 +16,12 @@ export function urlToRequire(
   transformAssetUrlsOption: TransformAssetUrlsOptions = {}
 ): string {
   const returnValue = `"${url}"`
-  if (isExternalUrl(url) || isDataUrl(url) || isHashUrl(url)) {
+  if (
+    isExternalUrl(url) ||
+    isDataUrl(url) ||
+    isHashUrl(url) ||
+    isNoProtocolImgUrlRe(url)
+  ) {
     return returnValue
   }
   // same logic as in transform-require.js
@@ -59,6 +64,11 @@ export function isExternalUrl(url: string): boolean {
 const dataUrlRE = /^\s*data:/i
 export function isDataUrl(url: string): boolean {
   return dataUrlRE.test(url)
+}
+
+const noProtocolImgUrlRe = /^(\/\/)[\s\S]+\.(jpe?g|png|svg|gif|webp|ico)/
+export function isNoProtocolImgUrlRe(url: string): boolean {
+  return noProtocolImgUrlRe.test(url)
 }
 
 /**


### PR DESCRIPTION
## Background
`vite-plugin-vue2@1.7.3`  will cause an absolute asset reference without protocol header in the template to report an error：

![image](https://user-images.githubusercontent.com/22092110/128609457-2ff22c93-cd99-4f59-b164-bb9a1fda1cf6.png)

![image](https://user-images.githubusercontent.com/22092110/128609494-5b93a92f-da8d-4ef9-ba0f-5557c1cdbcc8.png)

## Minirepo
Can run `yarn dev` in  `vite-plugin-vue2/playground`

<br>

I've provided a separate comparison of the default vite project and the vite-plugin-vue2 project
> 我另外提供了一个 vite 默认创建项目和 vite-plugin-vue2 的对比。当前的 vite-plugin-vue2 实现方式会导致没有协议头的图片路径请求出现问题: 
> src: //cli.vuejs.org/favicon.png  **=>** src: require('xxx') **=>**  import __$_require_xxx__ ;        src: __$_require_xxx__ 



https://github.com/screetBloom/vite-mini-repo/tree/main/packages
![image](https://user-images.githubusercontent.com/22092110/128609725-5c3d2e18-6760-447b-91c1-9433d2798791.png)






