### PR TITLE
feat: add allowDeclareFields for babel ts option

### DIFF
--- a/src/jsxTransform.ts
+++ b/src/jsxTransform.ts
@@ -16,7 +16,7 @@ export function transformVueJsx(
   if (/\.tsx$/.test(id)) {
     plugins.unshift([
       require.resolve('@babel/plugin-transform-typescript'),
-      { isTSX: true, allowExtensions: true },
+      { isTSX: true, allowExtensions: true, allowDeclareFields: true },
     ])
   }
 


### PR DESCRIPTION
Allow using `declare` in `vue-class-component`

```js
@Component
export default class HelloWorld extends Vue {
  // non-reactive
  declare foo: number;
}
```