### PR TITLE
Don't import from typescript source files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { TemplateCompileOptions } from '@vue/component-compiler-utils/lib/compileTemplate'
+import { TemplateCompileOptions } from '@vue/component-compiler-utils'
 import { normalizeComponentCode } from './utils/componentNormalizer'
 import { vueHotReloadCode } from './utils/vueHotReload'
 import fs from 'fs'


### PR DESCRIPTION
Importing from typescript source files distributed with a module causes user projects to type check those source files using the tsconfig of the user project rather than that of the module, with stricter settings raising errors that are not actually errors but simply stricter type check settings.

See https://github.com/microsoft/TypeScript/issues/40426