### PR TITLE
fix: ignore import transform for absolute urls

### DIFF
--- a/src/template/utils.ts
+++ b/src/template/utils.ts
@@ -16,7 +16,12 @@ export function urlToRequire(
   transformAssetUrlsOption: TransformAssetUrlsOptions = {}
 ): string {
   const returnValue = `"${url}"`
-  if (isExternalUrl(url) || isDataUrl(url) || isHashUrl(url)) {
+  if (
+    isExternalUrl(url) ||
+    isDataUrl(url) ||
+    isHashUrl(url) ||
+    isAbsolute(url)
+  ) {
     return returnValue
   }
   // same logic as in transform-require.js
@@ -59,6 +64,10 @@ export function isExternalUrl(url: string): boolean {
 const dataUrlRE = /^\s*data:/i
 export function isDataUrl(url: string): boolean {
   return dataUrlRE.test(url)
+}
+
+export function isAbsolute(url: string): boolean {
+  return url.startsWith('/')
 }
 
 /**


### PR DESCRIPTION
Before this fix, assets with absolute urls will be prepend with `?import` and result error on client side

![image](https://user-images.githubusercontent.com/11247099/132195560-001980d0-d6da-49c8-b088-f04445bf93ee.png)
