### PR TITLE
feat: add 'target' options for transform script code

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -39,6 +39,12 @@ Type: `Object`<br>
 
 The options for `@vue/babel-preset-jsx`.
 
+### `target`
+
+Type: `String`<br>
+
+The options for esbuild to transform script code
+
 ## Todo
 
 - SSR Build

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,12 +39,17 @@ export interface VueViteOptions {
    * The options for `@vue/babel-preset-jsx`
    */
   jsxOptions?: Record<string, any>
+  /**
+   * The options for esbuld to transform script code
+   */
+  target?: string
 }
 
 export interface ResolvedOptions extends VueViteOptions {
   root: string
   devServer?: ViteDevServer
   isProduction: boolean
+  target?: string
 }
 
 export function createVuePlugin(rawOptions: VueViteOptions = {}): Plugin {

--- a/src/main.ts
+++ b/src/main.ts
@@ -152,7 +152,7 @@ async function genScriptCode(
         const result = await options.devServer!.transformWithEsbuild(
           scriptCode,
           filename,
-          { loader: 'ts' },
+          { loader: 'ts', target: options.target },
           map
         )
         scriptCode = result.code


### PR DESCRIPTION
A modification to make this plugin support transform ECMAScript to lower version when transform script code