### PR TITLE
fix: error when SFC script contains variable named render, staticRenderFns, etc

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ export async function transformMain(
     pluginContext
   )
   // script
-  const scriptVar = 'script'
+  const scriptVar = '__vue2_script'
   const { scriptCode, map: scriptMap } = await genScriptCode(
     scriptVar,
     descriptor,
@@ -49,13 +49,13 @@ ${templateCode}
 const ${cssModuleVar} = {}
 ${stylesCode}
 /* normalize component */
-import normalizer from "${vueComponentNormalizer}"
-var __component__ = /*#__PURE__*/normalizer(
-  script,
-  render,
-  staticRenderFns,
+import __vue2_normalizer from "${vueComponentNormalizer}"
+var __component__ = /*#__PURE__*/__vue2_normalizer(
+  __vue2_script,
+  __vue2_render,
+  __vue2_staticRenderFns,
   ${hasFunctional ? `true` : `false`},
-  injectStyles,
+  __vue2_injectStyles,
   ${scoped ? JSON.stringify(descriptor.id) : `null`},
   null,
   null
@@ -63,7 +63,7 @@ var __component__ = /*#__PURE__*/normalizer(
   `.trim() + `\n`
 
   result += `
-function injectStyles (context) {
+function __vue2_injectStyles (context) {
   for(let o in ${cssModuleVar}){
     this[o] = ${cssModuleVar}[o]
   }
@@ -183,7 +183,7 @@ async function genTemplateRequest(
 ) {
   const template = descriptor.template
   if (!template) {
-    return { code: `let render, staticRenderFns` }
+    return { code: `let __vue2_render, __vue2_staticRenderFns` }
   }
   const src = template.src || filename
   const srcQuery = template.src ? `&src` : ``
@@ -192,7 +192,7 @@ async function genTemplateRequest(
   const query = `?vue${from}&type=template${srcQuery}${attrsQuery}`
   const templateRequest = src + query
   return {
-    code: `import { render, staticRenderFns } from '${templateRequest}'`,
+    code: `import { render as __vue2_render, staticRenderFns as __vue2_staticRenderFns } from '${templateRequest}'`,
     templateRequest,
   }
 }


### PR DESCRIPTION
This plugin injects code into the same scope as the script code, but also introduces variables. These
variables can lead to errors when a script also contains a symbol with the same name. I have applied
some additional namespacing to make it more unlikely that these variable names would collide with
a user's code, and additionally less likely to collide with other generated code.

To reproduce the error, you can create a .vue file with the following content:
```
<script lang="ts">
import Vue from "vue";

const render = function() {
  console.log('test');
}

export default Vue.extend({
  mounted() {
    render();
  }
});
</script>
```

![image](https://user-images.githubusercontent.com/17907922/136843279-b4512d53-a033-4d4f-98f3-4f68babf7547.png)

Looking at the output, likely candidates for collisions with user-generated code are:
* render
* script
* staticRenderFns
* normalizer
* injectStyles

And there are a few that use different styles of escaping already:
* `__cssModules`
* `__component__`

I wasn't sure if those were based on conventions used elsewhere and as a result didn't touch them, however, I'm not exactly happy with the new situation of having `__*`, `__*__` and `__vue2_*` all in the same file, so I'm open to which ever form of escaping the project maintainers are willing to accept.