### PR TITLE
fix: missing sourcemap fields after compiling ts in dev

### DIFF
--- a/playground/TestTsSFC.vue
+++ b/playground/TestTsSFC.vue
@@ -1,0 +1,5 @@
+<script lang="ts">
+import Vue from 'vue'
+export default Vue.extend({
+})
+</script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import path from 'path'
 import fs from 'fs'
 import { TransformPluginContext } from 'rollup'
 import { RawSourceMap, SourceMapGenerator } from 'source-map'
+import * as Vite from 'vite'
 
 export async function transformMain(
   code: string,
@@ -149,7 +150,10 @@ async function genScriptCode(
       }
       map = script.map
       if (script.lang === 'ts') {
-        const result = await options.devServer!.transformWithEsbuild(
+        // transformWithEsbuild has been exported since vite@2.6.0-beta.0
+        const transformWithEsbuild =
+          Vite.transformWithEsbuild ?? options.devServer!.transformWithEsbuild
+        const result = await transformWithEsbuild(
           scriptCode,
           filename,
           { loader: 'ts', target: options.target },
@@ -157,6 +161,13 @@ async function genScriptCode(
         )
         scriptCode = result.code
         map = result.map
+        // restore esbuild missing sourcemap fields from previous compilation
+        if (!map.file && script.map?.file) {
+          map.file = script.map.file
+        }
+        if (!map.sourcesContent && script.map?.sourcesContent) {
+          map.sourcesContent = script.map.sourcesContent
+        }
       }
     } else {
       const src = script.src || filename

--- a/test/unit.spec.ts
+++ b/test/unit.spec.ts
@@ -1,0 +1,32 @@
+import fs from 'fs-extra'
+import path from 'path'
+import { transformMain } from '../src/main'
+
+const fixtureDir = path.join(__dirname, '../playground')
+
+jest.setTimeout(100000)
+
+describe('vite-plugin-vue2', () => {
+  describe('unit', () => {
+    test('should genScriptCode return complete sourcemap when lang=ts', async () => {
+      const filePath = path.join(fixtureDir, 'TestTsSFC.vue')
+      const code = fs.readFileSync(filePath).toString()
+      const { map: scriptMap } = await transformMain(
+        code,
+        filePath,
+        {
+          isProduction: false,
+          root: fixtureDir,
+          // @ts-ignore need mock if it will be used in the future
+          devServer: {},
+        },
+        // @ts-ignore need mock if it will be used in the future
+        {}
+      )
+      expect(scriptMap).toHaveProperty('file')
+      expect(scriptMap).toHaveProperty('sourcesContent')
+      expect(scriptMap!.file).toEqual(filePath)
+      expect(scriptMap!.sourcesContent).toEqual([code])
+    })
+  })
+})


### PR DESCRIPTION
If other Vite plugin transformed vue code before `vite-plugin-vue2`, the code passed to `transform()` will be the modified code.

But if the code source is TypeScript, the esbuild transform result will miss some sourcemap fields like `sourcesContent`. it will cause rollup try to read source content from file system (its different from modified code) when generating sourcemap, so the final sourcemap cannot be mapped to current source.

This PR fixed it by adding missing fields from previous map.