### PR TITLE
fix: srcset empty value judgment

### DIFF
--- a/src/template/srcset.ts
+++ b/src/template/srcset.ts
@@ -28,6 +28,9 @@ function transform(
       if (attr.name === 'srcset') {
         // same logic as in transform-require.js
         const value = attr.value
+        if (value === '""') {
+          return
+        }
         const isStatic =
           value.charAt(0) === '"' && value.charAt(value.length - 1) === '"'
         if (!isStatic) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49627376/160320378-887b3102-5138-4a14-a2c0-e08c203084e3.png)
![image](https://user-images.githubusercontent.com/49627376/160320402-2b26b83d-7956-4ba3-8f05-23a4e80186cd.png)
When srcset is empty, it is compiled as require ("")