### PR TITLE
feat: support vite 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "pre-commit": "lint-staged"
   },
   "peerDependencies": {
-    "vite": "^2.0.0",
+    "vite": "^2.0.0 || ^3.0.0",
     "vue-template-compiler": "^2.2.0"
   },
   "dependencies": {


### PR DESCRIPTION
[Vite v3.0.0 released](https://github.com/vitejs/vite/releases/tag/v3.0.0), this change makes sure `npm install` doesn't give peerDependency errors when using in combination with Vite 3.